### PR TITLE
Issue #9, #11, #13: Conditionally set attribute role `menubar` when edit menu has sub sections

### DIFF
--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.html
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.html
@@ -1,4 +1,4 @@
-<div class="dso-edit-menu d-flex" role="menubar">
+<div class="dso-edit-menu d-flex" [attr.role]="(hasSubSections | async) ? 'menubar' : null">
   @for (section of (sections | async); track section) {
     <div class="ms-1">
       <ng-container

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.ts
@@ -7,6 +7,7 @@ import {
   Injector,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
 import { AuthorizationDataService } from 'src/app/core/data/feature-authorization/authorization-data.service';
 
 import { MenuComponent } from '../../menu/menu.component';
@@ -34,6 +35,15 @@ export class DsoEditMenuComponent extends MenuComponent {
    */
   menuID = MenuID.DSO_EDIT;
 
+  /**
+   * Whether the DSO_EDIT menu has sub sections.
+   * 
+   * This is used to determine if the menu items will be
+   * rendered within the role="menubar".
+   * 
+   * @type {Observable<boolean>}
+   */
+  hasSubSections: Observable<boolean>;
 
   constructor(protected menuService: MenuService,
               protected injector: Injector,
@@ -42,6 +52,11 @@ export class DsoEditMenuComponent extends MenuComponent {
               protected themeService: ThemeService,
   ) {
     super(menuService, injector, authorizationService, route, themeService);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    this.hasSubSections = this.menuService.hasSubSections(this.menuID, null);
   }
 
 }


### PR DESCRIPTION
## References

* Fixes #9
* Fixes #11 
* Fixes #13

## Description

This change is to resolve a 'Broken ARIA menu' ADA compliance violation with community pages menu for anonymous users where the menu is rendered with no menu items. This was accomplished by adding the role conditionally on whether the menu is visible with visible sections.

## Instructions for Reviewers

The WAVE plugin in Chrome can be used to verify it no longer exists.

List of changes in this PR:
* First, update `menuVisible` to be observable of `isMenuVisibleWithVisibleSections`.
* Second, use `[attr.role]` to conditionally specify the role of the element as `menubar`.

To test this, install WAVE Chrome extension, navigate to a community page and turn on the WAVE extension to see if the error is no longer there.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
