### PR TITLE
Issue #10, #12: Add tamu theme search result component single h1 customization

### DIFF
--- a/src/themes/tamu/app/shared/search/search-results/search-results.component.html
+++ b/src/themes/tamu/app/shared/search/search-results/search-results.component.html
@@ -1,0 +1,65 @@
+@if ((activeFilters$ | async).length > 0 && (appliedFilters$ | async).length === 0) {
+  <div class="row">
+    <div class="col-12">
+      <div class="filters-badge-skeleton-container">
+        <div class="filter-badge-skeleton">
+          <ngx-skeleton-loader [count]="(activeFilters$ | async).length" />
+        </div>
+      </div>
+    </div>
+  </div>
+}
+
+<div class="d-flex justify-content-between">
+  @if (!disableHeader) {
+    <!-- TAMU Customization - single h1 element per community search page -->
+    <!-- <h1>{{ (configuration ? configuration + '.search.results.head' : 'search.results.head') | translate }}</h1> -->
+    <span class="h1">{{ (configuration ? configuration + '.search.results.head' : 'search.results.head') | translate }}</span>
+    <!-- END TAMU Customization - single h1 element per community search page -->
+  }
+  @if (showCsvExport) {
+    <ds-search-export-csv [searchConfig]="searchConfig" [total]="searchResults?.payload?.totalElements"></ds-search-export-csv>
+  }
+</div>
+@if (searchResults && searchResults?.hasSucceeded && !searchResults?.isLoading && searchResults?.payload?.page.length > 0) {
+  <div @fadeIn>
+    <ds-viewable-collection
+      [config]="searchConfig.pagination"
+      [sortConfig]="searchConfig.sort"
+      [objects]="searchResults"
+      [hideGear]="true"
+      [showRSS]="true"
+      [selectable]="selectable"
+      [selectionConfig]="selectionConfig"
+      [linkType]="linkType"
+      [context]="context"
+      [hidePaginationDetail]="hidePaginationDetail"
+      [showThumbnails]="showThumbnails"
+      (contentChange)="contentChange.emit($event)"
+      (deselectObject)="deselectObject.emit($event)"
+      (selectObject)="selectObject.emit($event)">
+    </ds-viewable-collection>
+  </div>
+}
+
+@if (isLoading()) {
+  <ds-search-results-skeleton
+    [showThumbnails]="showThumbnails"
+    [numberOfResults]="searchConfig.pagination.pageSize"
+  ></ds-search-results-skeleton>
+}
+
+@if (showError()) {
+  <ds-error
+  message="{{errorMessageLabel() | translate}}"></ds-error>
+}
+@if (searchResults?.payload?.page.length === 0 || searchResults?.statusCode === 400) {
+  <div>
+    {{ 'search.results.no-results' | translate }}
+    <a [routerLink]="['/search']"
+      [queryParams]="{ query: surroundStringWithQuotes(searchConfig?.query) }"
+      queryParamsHandling="merge" role="link" tabindex="0">
+      {{"search.results.no-results-link" | translate}}
+    </a>
+  </div>
+}

--- a/src/themes/tamu/app/shared/search/search-results/search-results.component.ts
+++ b/src/themes/tamu/app/shared/search/search-results/search-results.component.ts
@@ -1,0 +1,39 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+
+import {
+  fadeIn,
+  fadeInOut,
+} from '../../../../../../app/shared/animations/fade';
+import { ErrorComponent } from '../../../../../../app/shared/error/error.component';
+import { ObjectCollectionComponent } from '../../../../../../app/shared/object-collection/object-collection.component';
+import { SearchExportCsvComponent } from '../../../../../../app/shared/search/search-export-csv/search-export-csv.component';
+import { SearchResultsComponent as BaseComponent } from '../../../../../../app/shared/search/search-results/search-results.component';
+import { SearchResultsSkeletonComponent } from '../../../../../../app/shared/search/search-results/search-results-skeleton/search-results-skeleton.component';
+
+@Component({
+  selector: 'ds-themed-search-results',
+  templateUrl: './search-results.component.html',
+  // templateUrl: '../../../../../../app/shared/search/search-results/search-results.component.html',
+  styleUrls: ['../../../../../../app/shared/search/search-results/search-results.component.scss'],
+  animations: [
+    fadeIn,
+    fadeInOut,
+  ],
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    ErrorComponent,
+    NgxSkeletonLoaderModule,
+    ObjectCollectionComponent,
+    RouterLink,
+    SearchExportCsvComponent,
+    SearchResultsSkeletonComponent,
+    TranslateModule,
+  ],
+})
+export class SearchResultsComponent extends BaseComponent {
+}

--- a/src/themes/tamu/eager-theme.module.ts
+++ b/src/themes/tamu/eager-theme.module.ts
@@ -10,6 +10,7 @@ import { NavbarComponent } from './app/navbar/navbar.component';
 // TAMU Customizations
 import { LoginPageComponent } from './app/login-page/login-page.component';
 import { LogoutPageComponent } from './app/logout-page/logout-page.component';
+import { SearchResultsComponent } from './app/shared/search/search-results/search-results.component';
 // END TAMU Customizations
 
 /**
@@ -26,7 +27,8 @@ const DECLARATIONS = [
   NavbarComponent,
   // TAMU Customizations
   LoginPageComponent,
-  LogoutPageComponent
+  LogoutPageComponent,
+  SearchResultsComponent,
   // END TAMU Customizations
 ];
 


### PR DESCRIPTION
## References

* Fixes #10
* Fixes #12

## Description

This customization is to replace the search results header h1 with span with class h1. I opted for the customization as opposed to changing core code as this is not strictly an ADA compliance violation and could have community push back.

## Instructions for Reviewers

Navigate to a community search results and check the element in the inspector tools to ensure it is a span with class h1.

List of changes in this PR:
* First, add tamu theme search results component.
* Second, replace h1 with span with class h1.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
