### PR TITLE
Issue #14: Improve screen reading of starts with input and hint text

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1105,17 +1105,13 @@
 
   "browse.startsWith.months.september": "September",
 
-  "browse.startsWith.placeholder": "Enter the first few letters",
-
   "browse.startsWith.submit": "Browse",
 
   "browse.startsWith.type_date": "Filter results by date",
 
   "browse.startsWith.type_date.label": "Or type in a date (year-month) and click on the Browse button",
 
-  "browse.startsWith.type_text": "To browse a location in the index, enter the first few letters. For a general search, click ",
-
-  "browse.startsWith.here": "here",
+  "browse.startsWith.type_text": "Filter results by typing the first few letters",
 
   "browse.startsWith.input": "Filter",
 

--- a/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
@@ -10,7 +10,7 @@
     </div>
     <small class="text-muted">
       <span aria-hidden="true">{{'browse.startsWith.input' | translate}}</span>
-      <span>{{'browse.startsWith.type_text' | translate}}</span>
+      <span aria-hidden="true">{{'browse.startsWith.type_text' | translate}}</span>
       <span><a [attr.aria-label]="'browse.startsWith.type_text' | translate" [routerLink]="['../../search']">{{'browse.startsWith.here' | translate}}</a>.</span>
     </small>
   </div>

--- a/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
@@ -9,8 +9,9 @@
       </div>
     </div>
     <small class="text-muted">
+      <span aria-hidden="true">{{'browse.startsWith.input' | translate}}</span>
       <span>{{'browse.startsWith.type_text' | translate}}</span>
-      <span><a [routerLink]="['../../search']">{{'browse.startsWith.here' | translate}}</a>.</span>
+      <span><a [attr.aria-label]="'browse.startsWith.type_text' | translate" [routerLink]="['../../search']">{{'browse.startsWith.here' | translate}}</a>.</span>
     </small>
   </div>
 </form>

--- a/src/themes/rdc/assets/i18n/en.json5
+++ b/src/themes/rdc/assets/i18n/en.json5
@@ -160,6 +160,10 @@
   "search.filters.filter.sponsor.placeholder": "Funding Agency",
   "search.filters.filter.sponsor.label": "Funding Agency",
 
+  "browse.startsWith.input": "To browse a location in the index, enter the first few letters. ",
+  "browse.startsWith.type_text": "For a general search, click ",
   "browse.startsWith.here": "here",
+
+  "browse.startsWith.placeholder": "Enter the first few letters",
 
 }


### PR DESCRIPTION
## References

* Fixes #14 

## Description

This PR is to improve the screen reading of the browse by starts with input and hint.

## Instructions for Reviewers

This change can be tested at https://data-dev.library.tamu.edu/browse/author.

Please use a screen reader to test while focus on the starts with input field within the browse by views.

List of changes in this PR:
* First, relocate `rdc` theme i18n variables into the theme assets. 
* Second, add `aria-label` to the starts with input box to read on focus.
* Third,  add `aria-hidden` to hint text not relevant to the link to discovery.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
