### PR TITLE
Add TAMU development config

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,3 @@
 config.*.yml
 !config.example.yml
+!config.tamu.yml

--- a/config/config.tamu.yml
+++ b/config/config.tamu.yml
@@ -1,0 +1,29 @@
+rest:
+  ssl: true
+  host: data-dev.library.tamu.edu
+  port: 443
+  nameSpace: /server
+
+themes:
+  - name: rdc
+    extends: tamu
+  - name: tamu
+    headTags:
+    - tagName: link
+      attributes:
+        rel: icon
+        href: assets/tamu/images/favicons/favicon.ico
+        sizes: any
+    - tagName: link
+      attributes:
+        rel: icon
+        href: assets/tamu/images/favicons/favicon.svg
+        type: image/svg+xml
+    - tagName: link
+      attributes:
+        rel: apple-touch-icon
+        href: assets/tamu/images/favicons/apple-touch-icon.png
+    - tagName: link
+      attributes:
+        rel: manifest
+        href: assets/tamu/images/favicons/manifest.webmanifest


### PR DESCRIPTION
This is intended to simplify development startup in which this file can be copied and named `config.dev.yml` and use `npm run start:dev` to begin development of data-dspace-angular with little overhead.