### PR TITLE
Issue #23: Improve accessibility of browse by issue date form

### DIFF
--- a/src/app/shared/starts-with/date/starts-with-date.component.html
+++ b/src/app/shared/starts-with/date/starts-with-date.component.html
@@ -5,7 +5,7 @@
     </span>
     <div class="col-6 col-md-2">
       <select id="year-select" class="form-select" (change)="setStartsWithYearEvent($event)" [attr.aria-label]="'browse.startsWith.choose_year.label' |translate">
-        <option [value]="-1" [selected]="!startsWithYear">
+        <option [value]="-1" [selected]="!startsWithYear" aria-label="">
           {{ 'browse.startsWith.choose_year' | translate }}
         </option>
         @for (option of startsWithOptions; track option) {
@@ -22,7 +22,8 @@
         @for (option of monthOptions; track option) {
           <option
             [value]="option"
-            [selected]="option === startsWithMonth ? 'selected': null">
+            [selected]="option === startsWithMonth ? 'selected': null"
+            [attr.aria-label]="option === 'none' ? '' : 'browse.startsWith.months.' + option | translate">
             {{ 'browse.startsWith.months.' + option | translate }}
           </option>
         }

--- a/src/app/shared/starts-with/date/starts-with-date.component.html
+++ b/src/app/shared/starts-with/date/starts-with-date.component.html
@@ -4,6 +4,7 @@
       {{ 'browse.startsWith.jump' | translate }}
     </span>
     <div class="col-6 col-md-2">
+      <label class="sr-only" for="year-select">{{ 'browse.startsWith.year' | translate }}</label>
       <select id="year-select" class="form-select" (change)="setStartsWithYearEvent($event)" [attr.aria-label]="'browse.startsWith.choose_year.label' |translate">
         <option [value]="-1" [selected]="!startsWithYear" aria-label="">
           {{ 'browse.startsWith.choose_year' | translate }}
@@ -18,6 +19,7 @@
       </select>
     </div>
     <div class="col-6 col-md-2">
+      <label class="sr-only" for="month-select">{{ 'browse.startsWith.month' | translate }}</label>
       <select id="month-select" class="form-select" (change)="setStartsWithMonthEvent($event)" [attr.aria-label]="'browse.startsWith.months.none.label' |translate">
         @for (option of monthOptions; track option) {
           <option

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1077,6 +1077,10 @@
 
   "browse.startsWith.jump": "Filter results by year or month",
 
+  "browse.startsWith.year": "Filter results by year",
+
+  "browse.startsWith.month": "Filter results by month",
+
   "browse.startsWith.months.april": "April",
 
   "browse.startsWith.months.august": "August",


### PR DESCRIPTION
## References

* Fixes #23 

## Description

These changes are to reduce the redundancy of the form inputs screen reading and assist screen readers with appropriate labels for input fields. The select aria-label will be read without reading the similar thing repeated in the option inner HTML. 

## Instructions for Reviewers

Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, add empty aria-label for non-value options.
* Second, add form label specifying for which input field. Added for screen reader only and not rendered.

This can be tested using NVDA tool and focusing on the select element. It should only read the aria-label of the select and not the non-value option inner HTML.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
